### PR TITLE
Create augmentTest

### DIFF
--- a/augmentTest
+++ b/augmentTest
@@ -1,0 +1,30 @@
+#run this file to augment a single image as a test
+
+from keras.preprocessing.image import ImageDataGenerator, array_to_img, img_to_array, load_img
+
+datagen = ImageDataGenerator(
+        rotation_range=40,
+        width_shift_range=0.2,
+        height_shift_range=0.2,
+        #keep this commented if only testing one image
+        #uncomment if running on full data set
+        #rescale=1./255
+        shear_range=0.2,
+        zoom_range=0.2,
+        horizontal_flip=True,
+        fill_mode='nearest')
+
+img = load_img('data/train/blues/blues.00000.png') #this takes the png and makes it a PIL image
+x = img_to_array(img) #this is a NumPy array representation of img, with shape (3, 678, 512)
+x = x.reshape((1,) + x.shape)  # this is a NumPy array representation of img, with shape (1, 3, 6
+# the shape of the NumPy array represents (number of examples, number of channels, width, height)
+
+# the .flow() command below generates batches of randomly transformed images
+# and saves the results to the `preview/` directory
+# in this case, only one image will be transformed
+i = 0
+for batch in datagen.flow(x, batch_size=1,
+                          save_to_dir='preview', save_prefix='blues', save_format='jpeg'):
+    i += 1
+    if i > 20:
+        break  # otherwise the generator would loop indefinitely


### PR DESCRIPTION
This file is a test for augmenting our TRAINING data. It should never be run on our test data! In order to view the augmented images properly, rescaling has been commented out. When this code is used in the full scale run, it should first - uncomment scaling - and second - loop through all ten genre folders in the training directory, augmenting EVERY image there.